### PR TITLE
Estute/deng 304

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,21 +5,26 @@ dbt-schema-builder
 |license-badge|
 
 The Schema Builder tool is used to create dbt schema files, sql models, and
-default PII / non-PII views for tables in the given Snowflake schemas. For
-each given ``<SCHEMA>_RAW`` schema the script will generate dbt models for a
-``<SCHEMA>`` and ``<SCHEMA>_PII`` schema. We refer to these schemas as a
+default PII / non-PII views for tables in the given Snowflake schemas.
+
+For each specified application schema, the script will generate dbt models for
+a ``<SCHEMA>`` and ``<SCHEMA>_PII`` schema. We refer to these schemas as a
 "trifecta".
 
-* ``<SCHEMA>_RAW`` contains the original source tables.
+* ``<SCHEMA>_<RAW_SUFFIX>`` contains the original source tables.
 * ``<SCHEMA>_PII`` contains views on the _RAW tables that have un-redacted PII.
 * ``<SCHEMA>`` contains views on the _RAW tables sensitive data redacted.
+
+Application schemas can be sourced from multiple raw schemas. This allows you
+to specify which tables should be pulled from which raw schema to construct the
+"trifecta".
 
 Schema Builder ensures that all three schemas provide the same interface to the
 data (number and order of columns match what is present in the _RAW schema).
 
 Once the script is successfully run, you can execute a `dbt run` to create or
 update the views in ``<SCHEMA>`` and ``<SCHEMA>_PII``. If your source data in
-the ``<SCHEMA>_RAW`` schema changes you should run Schema Builder frequently
+the ``<SCHEMA>_<RAW_SUFFIX>`` schema changes you should run Schema Builder frequently
 to keep up with changes in the tables and columns stored there.
 
 Schema Builder will also automatically create sources in one or more other dbt

--- a/dbt_schema_builder/app.py
+++ b/dbt_schema_builder/app.py
@@ -1,0 +1,154 @@
+"""
+Class and helpers for dealing with Application schemas
+"""
+
+from dbt.logger import GLOBAL_LOGGER as logger
+
+from .relation import DEFAULT_DESCRIPTION
+
+
+class App():
+    """
+    Class to represent an application whose data is managed by DBT and provides
+    functionality for updating its downstreams. An app can be backed by multiple
+    raw schemas.
+    """
+
+    def __init__(
+        self, raw_schemas, app, app_path, design_file_path, current_raw_sources,
+        current_downstream_sources, database
+    ):
+
+        self.raw_schemas = raw_schemas
+        self.app = app
+        self.app_path = app_path
+        self.design_file_path = design_file_path
+        self.current_raw_sources = current_raw_sources
+        self.current_downstream_sources = current_downstream_sources
+        self.safe_downstream_source_name = app
+        self.pii_downstream_source_name = "{}_PII".format(app)
+
+        # Create a new, empty object to store a new version of our schema so we
+        # don't get any tables/models that may have been deleted since the last run.
+        self.new_schema = {
+            "version": 2,
+            "sources": [
+                {"name": rs.schema_name, "tables": []}
+                for rs in self.raw_schemas
+            ],
+            "models": [],
+        }
+
+        # Create a new, empty object to store a new version of our downstream
+        # sources so we don't get any tables / models that may have been
+        # deleted since the last run.
+        self.new_downstream_sources = {
+            "version": 2,
+            "sources": [
+                {
+                    "name": self.safe_downstream_source_name,
+                    "database": database,
+                    "tables": [],
+                },
+                {
+                    "name": self.pii_downstream_source_name,
+                    "database": database,
+                    "tables": [],
+                },
+            ],
+            "models": [],
+        }
+
+    def __repr__(self):
+        """
+        Makes debugging less of a pain
+        """
+        return self.app
+
+    def add_source_to_new_schema(self, current_raw_source, relation, raw_schema):
+        """
+        Add our table to the appropriate raw schema entry in our "sources" list
+        in the new schema.
+        """
+        for index, item in enumerate(self.new_schema["sources"]):
+            if item['name'] == raw_schema.schema_name:
+                source_index = index
+                break
+
+        if current_raw_source:
+            self.new_schema["sources"][source_index]["tables"].append(
+                current_raw_source
+            )
+        else:
+            self.new_schema["sources"][source_index]["tables"].append(
+                {"name": relation.source_relation_name}
+            )
+
+    def add_table_to_downstream_sources(self, relation, current_safe_source, current_pii_source):
+        """
+        Whenever there is no view generated for a relation, we should not add it to sources in the
+        downstream project.  If we did, the source would be non-functional since it would not be
+        backed by any real data!  No view is generated under the following condition: when the
+        relation is unmanaged AND no manual models exist.
+        """
+        if relation.is_unmanaged and not relation.manual_safe_model_exists:
+            logger.info(
+                (
+                    "{}.{} is an unmanaged table WITHOUT a manual model, "
+                    "skipping inclusion as a source in downstream project."
+                ).format(relation.app, relation.relation)
+            )
+        elif relation.excluded_from_downstream_sources:
+            logger.info(
+                (
+                    "{}.{} is absent from the downstream sources allow_list, "
+                    "skipping inclusion as a source in downstream project."
+                ).format(relation.app, relation.relation)
+            )
+        elif current_safe_source:
+            for source in self.new_downstream_sources["sources"]:
+                if source["name"] == self.safe_downstream_source_name:
+                    source["tables"].append(current_safe_source)
+                elif source["name"] == self.pii_downstream_source_name:
+                    source["tables"].append(current_pii_source)
+        else:
+            for source in self.new_downstream_sources["sources"]:
+                if source["name"] == self.safe_downstream_source_name:
+                    source["tables"].append(
+                        {
+                            "name": relation.relation,
+                            "description": DEFAULT_DESCRIPTION,
+                        }
+                    )
+                elif source["name"] == self.pii_downstream_source_name:
+                    source["tables"].append(
+                        {
+                            "name": relation.relation,
+                            "description": DEFAULT_DESCRIPTION,
+                        }
+                    )
+
+    def update_trifecta_models(self, relation):
+        """
+        Given a relation, add it to the 'trifecta'. These are the PII and safe views
+        constructed from the raw data.
+        """
+        for relation_name in [
+            relation.new_pii_relation_name,
+            relation.new_safe_relation_name,
+        ]:
+            self.add_model_to_new_schema(
+                relation_name, relation.meta_data
+            )
+
+    def add_model_to_new_schema(self, new_relation_name, model_meta_data):
+        """
+        Add models and their columns to a schema that is currently being generated.
+        """
+        # Add our table to the "models" list in the new schema
+        self.new_schema["models"].append({"name": new_relation_name})
+
+        # Add columns to our model
+        new_cols = [{"name": c} for c in model_meta_data]
+
+        self.new_schema["models"][-1]["columns"] = new_cols

--- a/dbt_schema_builder/relation.py
+++ b/dbt_schema_builder/relation.py
@@ -31,6 +31,9 @@ class Relation():
         self.unmanaged_tables = unmanaged_tables
         self.downstream_sources_allow_list = downstream_sources_allow_list
 
+    def __repr__(self):
+        return self.source_relation_name
+
     def _get_model_name_alias(self):
         if self.source_relation_name in self.snowflake_keywords:
             return "_{}".format(self.source_relation_name)

--- a/dbt_schema_builder/schema_builder.py
+++ b/dbt_schema_builder/schema_builder.py
@@ -52,19 +52,6 @@ def parse_args(args):
     build_sub.set_defaults(cls=SchemaBuilderTask, which="build")
 
     build_sub.add_argument(
-        "--raw-schemas",
-        required=True,
-        nargs="+",
-        help="Required. Specify the RAW schemas to inspect when building schema.yml files.",
-    )
-
-    build_sub.add_argument(
-        "--raw-suffixes",
-        nargs="+",
-        help="Specify the suffixes to remove when building PII/Non-PII schema for Stitch.",
-    )
-
-    build_sub.add_argument(
         "--destination-project",
         required=True,
         help="Required. Specify the project that will use the generated sources, relative to the source project.",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,11 +24,30 @@ inside an existing dbt project, see :ref:`getting_started` for more information.
 to your dbt profiles.yml>] [--profile <profile name>] [--target <a target from
 profiles.yml>]``
 
-Required Parameters
+Config file
 
-``--raw-schemas`` - a space separated list of source schemas to work on. For
-every table in this schema a view will be created in the ``<SCHEMA>`` and
-``<SCHEMA_PII>`` schema based on your settings.
+In order to run, you must have a schema config file (``schema_config.yml``)
+in the directory in which you are running schema builder. This file must
+be in the following format::
+
+    <APPLICATION SCHEMA_1>:
+        <RAW SCHEMA 1>:
+            INCLUDE:
+                - TABLE_1
+        <RAW SCHEMA 2>:
+            EXCLUDE:
+                - TABLE_1
+    <APPLICATION SCHEMA_2>:
+        <RAW SCHEMA 3>:
+
+In the above example, the ``APPLICATION_SCHEMA_1`` will be built by combining
+*ONLY* ``TABLE_1`` from ``RAW_SCHEMA_1`` and all tables *BUT* ``TABLE_1`` from
+``RAW_SCHEMA_2``. ``APPLICATION_SCHEMA_2`` will be built from every table in
+``RAW_SCHEMA_3``.
+
+NOTE: the order of the ``RAW`` schemas above does not matter.
+
+Required Parameters
 
 ``--destination-project`` - the dbt project that will use the generated
 sources. Schema Builder will create or overwrite the source file(s) associated

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,225 @@
+"""
+Tests for the App class
+"""
+
+from dbt_schema_builder.app import App
+from dbt_schema_builder.relation import Relation
+from dbt_schema_builder.schema import Schema
+
+
+def test_add_source_to_new_schema():
+    schema_1 = Schema('LMS_TEST_RAW', [], [])
+    schema_2 = Schema('LMS_RAW', [], [])
+    schema_3 = Schema('LMS_STITCH_RAW', [], [])
+    raw_schemas = [schema_1, schema_2, schema_3]
+    app = App(
+        raw_schemas,
+        'LMS',
+        'models/PROD/LMS',
+        'models/PROD/LMS/LMS.yml',
+        {},
+        {},
+        'PROD'
+    )
+
+    current_raw_source = None
+    relation = Relation(
+        'THIS_TABLE',
+        ['COLUMN_1', 'COLUMN_2'],
+        'LMS',
+        'models/PROD/LMS',
+        ['START', 'END'],
+        [],
+        []
+    )
+    app.add_source_to_new_schema(current_raw_source, relation, schema_2)
+
+    current_raw_source = {"name": "THAT_TABLE", "description": "some special description"}
+    relation = Relation(
+        'THAT_TABLE',
+        ['COLUMN_3', 'COLUMN_4'],
+        'LMS',
+        'models/PROD/LMS',
+        ['START', 'END'],
+        [],
+        []
+    )
+    app.add_source_to_new_schema(current_raw_source, relation, schema_2)
+
+    expected_schema = {
+        "version": 2,
+        "sources": [
+            {
+                "name": 'LMS_TEST_RAW', "tables": []
+            },
+            {
+                "name": 'LMS_RAW', "tables": [
+                    {"name": 'THIS_TABLE'},
+                    {"name": 'THAT_TABLE', "description": "some special description"},
+                ]
+            },
+            {
+                "name": 'LMS_STITCH_RAW', "tables": []
+            },
+        ],
+        "models": [],
+    }
+
+    assert app.new_schema == expected_schema
+
+
+def test_update_trifecta_models():
+    raw_schemas = [
+        Schema('LMS_RAW', [], [])
+    ]
+    app = App(
+        raw_schemas,
+        'LMS',
+        'models/PROD/LMS',
+        'models/PROD/LMS/LMS.yml',
+        {},
+        {},
+        'PROD'
+    )
+
+    relation = Relation(
+        'THIS_TABLE',
+        ['COLUMN_1', 'COLUMN_2'],
+        'LMS',
+        'models/PROD/LMS',
+        ['START', 'END'],
+        [],
+        []
+    )
+
+    app.update_trifecta_models(relation)
+    expected_schema = {
+        "version": 2,
+        "sources": [
+            {
+                "name": "LMS_RAW",
+                "tables": []
+            }
+        ],
+        "models": [
+            {
+                "name": "LMS_PII_THIS_TABLE",
+                "columns": [
+                    {"name": "COLUMN_1"},
+                    {"name": "COLUMN_2"},
+                ]
+            },
+            {
+                "name": "LMS_THIS_TABLE",
+                "columns": [
+                    {"name": "COLUMN_1"},
+                    {"name": "COLUMN_2"},
+                ]
+            }
+        ],
+    }
+
+    assert app.new_schema == expected_schema
+
+
+def test_add_table_to_downstream_sources(tmpdir):
+    app_path_base = tmpdir.mkdir('models')
+    db_path = app_path_base.mkdir('PROD')
+    app_path = db_path.mkdir('LMS')
+    manual_model_path = app_path.mkdir('LMS_MANUAL')
+    manual_model_file = manual_model_path.join("LMS_TABLE.sql")
+    manual_model_file.write('data')
+
+    raw_schemas = [
+        Schema('LMS_RAW', [], [])
+    ]
+    app = App(
+        raw_schemas,
+        'LMS',
+        'models/PROD/LMS',
+        'models/PROD/LMS/LMS.yml',
+        {},
+        {},
+        'PROD'
+    )
+
+    relation = Relation(
+        'THIS_TABLE',
+        ['COLUMN_1', 'COLUMN_2'],
+        'LMS',
+        'models/PROD/LMS',
+        ['START', 'END'],
+        [],
+        []
+    )
+
+    app.add_table_to_downstream_sources(relation, None, None)
+
+    relation = Relation(
+        'THIS_TABLE',
+        ['COLUMN_1', 'COLUMN_2'],
+        'LMS',
+        'models/PROD/LMS',
+        ['START', 'END'],
+        [],
+        []
+    )
+    current_safe_downstream_source = {
+        'name': 'THAT_TABLE',
+        'description': 'Make sure all of the aspects of this are preserved',
+        "freshness": {
+            "warn_after": {
+                "count": "24",
+                "period": "hour"
+            },
+            "error_after": {
+                "count": "36",
+                "period": "hour"
+            }
+        },
+        "loaded_at_field": "last_login"
+    }
+    current_pii_downstream_source = {'name': 'THAT_TABLE', 'description': 'Expect this'}
+
+    app.add_table_to_downstream_sources(
+        relation, current_safe_downstream_source, current_pii_downstream_source
+    )
+
+    expected_downstream_sources = {
+        "version": 2,
+        "sources": [
+            {
+                "name": 'LMS',
+                "database": 'PROD',
+                "tables": [
+                    {'name': 'THIS_TABLE', 'description': 'TODO: Replace me'},
+                    {
+                        'name': 'THAT_TABLE',
+                        'description': 'Make sure all of the aspects of this are preserved',
+                        "freshness": {
+                            "warn_after": {
+                                "count": "24",
+                                "period": "hour"
+                            },
+                            "error_after": {
+                                "count": "36",
+                                "period": "hour"
+                            }
+                        },
+                        "loaded_at_field": "last_login"
+                    }
+                ]
+            },
+            {
+                "name": 'LMS_PII',
+                "database": 'PROD',
+                "tables": [
+                    {'name': 'THIS_TABLE', 'description': 'TODO: Replace me'},
+                    {'name': 'THAT_TABLE', 'description': 'Expect this'}
+                ],
+            },
+        ],
+        "models": [],
+    }
+
+    assert app.new_downstream_sources == expected_downstream_sources

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,51 @@
+"""
+Tests for various things in builder.py
+"""
+
+import pytest
+
+from dbt_schema_builder.builder import validate_schema_config
+from dbt_schema_builder.schema import InvalidConfigurationException
+
+
+def test_valid_config():
+    config = {
+        'APP_1': {
+            'RAW_SCHEMA_1': {
+                'INCLUDE': [
+                    'TABLE_1',
+                    'TABLE_2',
+                ]
+            },
+            'RAW_SCHEMA_2': {
+                'INCLUDE': [
+                    'TABLE_1',
+                    'TABLE_2',
+                ]
+            }
+        },
+        'APP_2': {
+            'RAW_SCHEMA_1': {},
+        },
+    }
+    assert validate_schema_config(config)
+
+
+def test_invalid_config_keys():
+    config = {
+        'APP_1': {
+            'RAW_SCHEMA_1': {
+                'INCLUDE': [
+                    'TABLE_1',
+                    'TABLE_2',
+                ],
+                'EXCLUDE': [
+                    'TABLE_1',
+                    'TABLE_2',
+                ]
+            },
+        },
+    }
+    with pytest.raises(InvalidConfigurationException) as excinfo:
+        validate_schema_config(config)
+    assert "has both an EXCLUDE and INCUDE section" in str(excinfo.value)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -6,160 +6,45 @@ from dbt_schema_builder.relation import Relation
 from dbt_schema_builder.schema import Schema
 
 
-def test_add_table_to_new_schema():
-    schema = Schema(
-        'LMS_RAW', 'LMS', 'models/PROD/LMS', 'models/PROD/LMS/LMS.yml', {}, {}, 'PROD'
-    )
+def test_raw_schema_filter_with_exclusion_list():
+    relations = [
+        Relation(
+            'THIS_TABLE', ['COLUMN_1', 'COLUMN_2'], 'LMS', 'models/PROD/LMS',
+            ['START', 'END'], [], []
+        ),
+        Relation(
+            'NOT_THIS_TABLE', ['COLUMN_1', 'COLUMN_2'], 'LMS', 'models/PROD/LMS',
+            ['START', 'END'], [], []
+        ),
+        Relation(
+            'THIS_TABLE_ALSO', ['COLUMN_1', 'COLUMN_2'], 'LMS', 'models/PROD/LMS',
+            ['START', 'END'], [], []
+        ),
+    ]
+    exclusion_list = ['NOT_THIS_TABLE']
+    raw_schema = Schema('LMS_RAW', exclusion_list, [], relations=relations)
+    filtered_relations = raw_schema.filter_relations()
 
-    current_raw_source = None
-    relation = Relation(
-        'THIS_TABLE', ['COLUMN_1', 'COLUMN_2'], 'LMS', 'models/PROD/LMS',
-        ['START', 'END'], [], []
-    )
-    schema.add_table_to_new_schema(current_raw_source, relation)
-
-    current_raw_source = {"name": "THAT_TABLE", "description": "some special description"}
-    relation = Relation(
-        'THAT_TABLE', ['COLUMN_3', 'COLUMN_4'], 'LMS', 'models/PROD/LMS',
-        ['START', 'END'], [], []
-    )
-    schema.add_table_to_new_schema(current_raw_source, relation)
-
-    expected_schema = {
-        "version": 2,
-        "sources": [
-            {
-                "name": 'LMS_RAW', "tables": [
-                    {"name": 'THIS_TABLE'},
-                    {"name": 'THAT_TABLE', "description": "some special description"},
-                ]
-            }
-        ],
-        "models": [],
-    }
-
-    assert schema.new_schema == expected_schema
+    assert len(filtered_relations) == 2
 
 
-def test_update_trifecta_models():
-    schema = Schema(
-        'LMS_RAW', 'LMS', 'models/PROD/LMS', 'models/PROD/LMS/LMS.yml', {}, {}, 'PROD'
-    )
+def test_raw_schema_filter_with_inclusion_list():
+    relations = [
+        Relation(
+            'NOT_THIS_TABLE', ['COLUMN_1', 'COLUMN_2'], 'LMS', 'models/PROD/LMS',
+            ['START', 'END'], [], []
+        ),
+        Relation(
+            'ONLY_THIS_TABLE', ['COLUMN_1', 'COLUMN_2'], 'LMS', 'models/PROD/LMS',
+            ['START', 'END'], [], []
+        ),
+        Relation(
+            'NOT_THIS_TABLE_EITHER', ['COLUMN_1', 'COLUMN_2'], 'LMS', 'models/PROD/LMS',
+            ['START', 'END'], [], []
+        ),
+    ]
+    inclusion_list = ['ONLY_THIS_TABLE']
+    raw_schema = Schema('LMS_RAW', [], inclusion_list, relations=relations)
+    filtered_relations = raw_schema.filter_relations()
 
-    relation = Relation(
-        'THIS_TABLE', ['COLUMN_1', 'COLUMN_2'], 'LMS', 'models/PROD/LMS',
-        ['START', 'END'], [], []
-    )
-
-    schema.update_trifecta_models(relation)
-    expected_schema = {
-        "version": 2,
-        "sources": [
-            {
-                "name": "LMS_RAW",
-                "tables": []
-            }
-        ],
-        "models": [
-            {
-                "name": "LMS_PII_THIS_TABLE",
-                "columns": [
-                    {"name": "COLUMN_1"},
-                    {"name": "COLUMN_2"},
-                ]
-            },
-            {
-                "name": "LMS_THIS_TABLE",
-                "columns": [
-                    {"name": "COLUMN_1"},
-                    {"name": "COLUMN_2"},
-                ]
-            }
-        ],
-    }
-
-    assert schema.new_schema == expected_schema
-
-
-def test_add_table_to_downstream_sources(tmpdir):
-    app_path_base = tmpdir.mkdir('models')
-    db_path = app_path_base.mkdir('PROD')
-    app_path = db_path.mkdir('LMS')
-    manual_model_path = app_path.mkdir('LMS_MANUAL')
-    manual_model_file = manual_model_path.join("LMS_TABLE.sql")
-    manual_model_file.write('data')
-
-    schema = Schema(
-        'LMS_RAW', 'LMS', 'models/PROD/LMS', 'models/PROD/LMS/LMS.yml', {}, {}, 'PROD'
-    )
-
-    relation = Relation(
-        'THIS_TABLE', ['COLUMN_1', 'COLUMN_2'], 'LMS', 'models/PROD/LMS',
-        ['START', 'END'], [], []
-    )
-
-    schema.add_table_to_downstream_sources(relation, None, None)
-
-    relation = Relation(
-        'THIS_TABLE', ['COLUMN_1', 'COLUMN_2'], 'LMS', 'models/PROD/LMS',
-        ['START', 'END'], [], []
-    )
-    current_safe_downstream_source = {
-        'name': 'THAT_TABLE',
-        'description': 'Make sure all of the aspects of this are preserved',
-        "freshness": {
-            "warn_after": {
-                "count": "24",
-                "period": "hour"
-            },
-            "error_after": {
-                "count": "36",
-                "period": "hour"
-            }
-        },
-        "loaded_at_field": "last_login"
-    }
-    current_pii_downstream_source = {'name': 'THAT_TABLE', 'description': 'Expect this'}
-
-    schema.add_table_to_downstream_sources(
-        relation, current_safe_downstream_source, current_pii_downstream_source
-    )
-
-    expected_downstream_sources = {
-        "version": 2,
-        "sources": [
-            {
-                "name": 'LMS',
-                "database": 'PROD',
-                "tables": [
-                    {'name': 'THIS_TABLE', 'description': 'TODO: Replace me'},
-                    {
-                        'name': 'THAT_TABLE',
-                        'description': 'Make sure all of the aspects of this are preserved',
-                        "freshness": {
-                            "warn_after": {
-                                "count": "24",
-                                "period": "hour"
-                            },
-                            "error_after": {
-                                "count": "36",
-                                "period": "hour"
-                            }
-                        },
-                        "loaded_at_field": "last_login"
-                    }
-                ]
-            },
-            {
-                "name": 'LMS_PII',
-                "database": 'PROD',
-                "tables": [
-                    {'name': 'THIS_TABLE', 'description': 'TODO: Replace me'},
-                    {'name': 'THAT_TABLE', 'description': 'Expect this'}
-                ],
-            },
-        ],
-        "models": [],
-    }
-
-    assert schema.new_downstream_sources == expected_downstream_sources
+    assert len(filtered_relations) == 1


### PR DESCRIPTION
This is a substantial refactor to support the ability to allow multiple RAW sources be used to create an application schema. Prior to this, there was a 1:1 mapping of RAW schema (say, LMS_RAW) to application schema (LMS) and the trifecta/downstreams. In order to do this, I had to change SB from using CLI arguments to specify schemas to using a config file, in the following format:
```
APP:
    RAW_SCHEMA_1:
         INCLUDE:
              - TABLE_1
    RAW_SCHEMA_2:
         EXCLUDE:
              - TABLE_1
```

In this case **ONLY** `TABLE_1` from `RAW_SCHEMA_1` and **EVERYTHING BUT** `TABLE_1` from `RAW_SCHEMA_2` will be used to create the schema for `APP`.

**TODO:**
* Update docs
* Check for malformed config files
* Handle soft-deletes