### PR TITLE
Bump package version after dbt upgrade to force req install.

### DIFF
--- a/dbt_schema_builder/__init__.py
+++ b/dbt_schema_builder/__init__.py
@@ -2,4 +2,4 @@
 Automate management of PII redacted schemas for dbt projects.
 """
 
-__version__ = '0.2.2'
+__version__ = '0.2.3'


### PR DESCRIPTION
**Description:** I checked the latest run of dbt-schema-builder here:

http://jenkins-new.analytics.edx.org/job/snowflake-schema-builder/168/console

The run didn't use the new version of dbt due to skipping a re-install of the package with the same version number. It seems that a version bump is required with dbt upgrades - at least with how we perform our Jenkins requirements installation.

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc.

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
