### PR TITLE
build schemas from other databases

### DIFF
--- a/dbt_schema_builder/app.py
+++ b/dbt_schema_builder/app.py
@@ -65,7 +65,7 @@ class App:
         """
         return self.app
 
-    def add_source_to_new_schema(self, current_raw_source, relation, raw_schema):
+    def add_source_to_new_schema(self, current_raw_source, relation, source_database, raw_schema):
         """
         Add our table to the appropriate raw schema entry in our "sources" list
         in the new schema.
@@ -74,6 +74,8 @@ class App:
             if item['name'] == raw_schema.schema_name:
                 source_index = index
                 break
+
+        self.new_schema["sources"][source_index]["database"] = source_database
 
         if current_raw_source:
             self.new_schema["sources"][source_index]["tables"].append(

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,15 +30,33 @@ In order to run, you must have a schema config file (``schema_config.yml``)
 in the directory in which you are running schema builder. This file must
 be in the following format::
 
-    <APPLICATION SCHEMA_1>:
-        <RAW SCHEMA 1>:
+    <DESTINATION_DATABASE>.<APPLICATION SCHEMA_1>:
+        <SOURCE_DATABASE>.<RAW SCHEMA 1>:
             INCLUDE:
                 - TABLE_1
-        <RAW SCHEMA 2>:
+        <SOURCE_DATABASE>.<RAW SCHEMA 2>:
             EXCLUDE:
                 - TABLE_1
-    <APPLICATION SCHEMA_2>:
-        <RAW SCHEMA 3>:
+    <DESTINATION_DATABASE>.<APPLICATION SCHEMA_2>:
+        <SOURCE_DATABASE>.<RAW SCHEMA 3>:
+
+At a high level, this file is describing how Schema Builder will use one or more
+source schemas to build out the dbt models for a destination schema.
+
+The top level keys in this file, i.e. `<DESTINATION_DATABASE>.<APPLICATION SCHEMA_1>`
+define the database and schema name that will be built by Schema Builder. There
+will be no change applied to the destinations. These are simply used as
+paths when building out a directory of dbt model files.
+
+The next level of keys in this file, i.e. `<SOURCE_DATABASE>.<RAW SCHEMA 3>`,
+define the database and schema name in Snowflake from which the current state
+of tables and columns will be queried. This structure data, along with any
+additional configurations, will be used to generate the dbt models in the
+destination schema described above.
+
+NOTE: source schemas and destination schemas can use different databases. This
+is particularly useful if you are trying to use a raw schema from a data-share
+to create downstream models in a database that your account has ownership of.
 
 In the above example, the ``APPLICATION_SCHEMA_1`` will be built by combining
 *ONLY* ``TABLE_1`` from ``RAW_SCHEMA_1`` and all tables *BUT* ``TABLE_1`` from
@@ -55,8 +73,8 @@ excluded from the downstream views.
 This feature is turned on and off per-schema and requires you to add the SQL
 you would like to *exclude* those rows::
 
-    <APPLICATION SCHEMA_1>:
-        <RAW SCHEMA 1>:
+    <DATABASE>.<APPLICATION SCHEMA_1>:
+        <DATABASE>.<RAW SCHEMA 1>:
             SOFT_DELETE:
                 DELETED_AT: IS NOT NULL
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -33,7 +33,7 @@ def test_add_source_to_new_schema():
         [],
         []
     )
-    app.add_source_to_new_schema(current_raw_source, relation, schema_2)
+    app.add_source_to_new_schema(current_raw_source, relation, 'PROD', schema_2)
 
     current_raw_source = {"name": "THAT_TABLE", "description": "some special description"}
     relation = Relation(
@@ -46,7 +46,7 @@ def test_add_source_to_new_schema():
         [],
         []
     )
-    app.add_source_to_new_schema(current_raw_source, relation, schema_2)
+    app.add_source_to_new_schema(current_raw_source, relation, 'PROD', schema_2)
 
     expected_schema = {
         "version": 2,
@@ -55,10 +55,12 @@ def test_add_source_to_new_schema():
                 "name": 'LMS_TEST_RAW', "database": "PROD", "tables": []
             },
             {
-                "name": 'LMS_RAW', "database": "PROD", "tables": [
+                "name": 'LMS_RAW',
+                "tables": [
                     {"name": 'THIS_TABLE'},
                     {"name": 'THAT_TABLE', "description": "some special description"},
-                ]
+                ],
+                "database": "PROD"
             },
             {
                 "name": 'LMS_STITCH_RAW', "database": "PROD", "tables": []
@@ -66,7 +68,6 @@ def test_add_source_to_new_schema():
         ],
         "models": [],
     }
-
     assert app.new_schema == expected_schema
 
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -10,14 +10,14 @@ from dbt_schema_builder.schema import InvalidConfigurationException
 
 def get_valid_test_config():
     return {
-        'APP_1': {
-            'RAW_SCHEMA_1': {
+        'DB_1.APP_1': {
+            'DB_1.RAW_SCHEMA_1': {
                 'INCLUDE': [
                     'TABLE_1',
                     'TABLE_2',
                 ]
             },
-            'RAW_SCHEMA_2': {
+            'DB_1.RAW_SCHEMA_2': {
                 'EXCLUDE': [
                     'TABLE_1',
                     'TABLE_2',
@@ -27,8 +27,8 @@ def get_valid_test_config():
                 }
             }
         },
-        'APP_2': {
-            'RAW_SCHEMA_1': {},
+        'DB_1.APP_2': {
+            'DB_1.RAW_SCHEMA_1': {},
         },
     }
 
@@ -40,8 +40,8 @@ def test_valid_config():
 
 def test_invalid_config_keys():
     config = {
-        'APP_1': {
-            'RAW_SCHEMA_1': {
+        'DB_1.APP_1': {
+            'DB_1.RAW_SCHEMA_1': {
                 'INCLUDE': [
                     'TABLE_1',
                     'TABLE_2',
@@ -60,8 +60,8 @@ def test_invalid_config_keys():
 
 def test_invalid_soft_delete_keys():
     config = {
-        'APP_1': {
-            'RAW_SCHEMA_1': {
+        'DB_1.APP_1': {
+            'DB_1.RAW_SCHEMA_1': {
                 'INCLUDE': [
                     'TABLE_1',
                     'TABLE_2',
@@ -75,11 +75,11 @@ def test_invalid_soft_delete_keys():
     with pytest.raises(InvalidConfigurationException) as excinfo:
         SchemaBuilder.validate_schema_config(config)
 
-    assert "The SOFT_DELETE key in RAW_SCHEMA_1 must map" in str(excinfo.value)
+    assert "The SOFT_DELETE key in DB_1.RAW_SCHEMA_1 must map" in str(excinfo.value)
 
     config = {
-        'APP_1': {
-            'RAW_SCHEMA_2': {
+        'DB_1.APP_1': {
+            'DB_1.RAW_SCHEMA_2': {
                 'EXCLUDE': [
                     'TABLE_1',
                     'TABLE_2',
@@ -95,6 +95,33 @@ def test_invalid_soft_delete_keys():
     with pytest.raises(InvalidConfigurationException) as excinfo:
         SchemaBuilder.validate_schema_config(config)
 
-    err_msg = "SOFT_DELETE key in RAW_SCHEMA_2 must only have one key/value"
+    err_msg = "SOFT_DELETE key in DB_1.RAW_SCHEMA_2 must only have one key/value"
 
+    assert err_msg in str(excinfo.value)
+
+
+def test_bad_destination_config_format():
+    config = {
+        'DB_1': {
+            'DB_1.RAW_SCHEMA_1': {},
+        }
+    }
+    with pytest.raises(InvalidConfigurationException) as excinfo:
+        SchemaBuilder.validate_schema_config(config)
+
+    err_msg = "Invalid destination schema path in schema_config.yml"
+    assert err_msg in str(excinfo.value)
+
+
+def test_bad_source_config_format():
+    config = {
+        'DB_1.APP_1': {
+            'RAW_SCHEMA_1': {},
+        }
+    }
+
+    with pytest.raises(InvalidConfigurationException) as excinfo:
+        SchemaBuilder.validate_schema_config(config)
+
+    err_msg = "Invalid source schema path in schema_config.yml"
     assert err_msg in str(excinfo.value)


### PR DESCRIPTION
I want to extend the dbt-schema-builder to allow us to build prod trifecta schemas from schemas in other databases.

We will be receiving a data share from Braze. We would like to create trifecta schemas (PII-redacted, DS&A accessible) in the prod database, but the datashare will be in its own database. Currently, the dbt-schema-builder can only work within one database (prod).

In the past, with other data shares (like the COVID-19), we created trifecta schemas in the prod database and manually created views from the datashare into the prod database. In this case, there are 150 tables in the Braze datashare. Doing this manually is quite brittle and would not account for new tables being added to the data share.

NOTE: schema builder needs permission to see read the data share, but datashares are only accessible via account_admin or roles that have the `imported privileges` permissions to look at data shares. 

To test this, I have used this branch to generate the following pull request, targeting only the COVID19 database (check the schema_config.yml file), which is built from a data-share: https://github.com/edx/warehouse-transforms/pull/1559

Once this merges, I will release a new version of schema-builder to PyPI. Then I will be able to merge and run this PR: https://github.com/edx/warehouse-transforms/pull/1563