### PR TITLE
dbt version upgrade v0.19.0

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,4 +1,4 @@
 # Core requirements for using this application
 -c constraints.txt
 
-dbt==0.18.1
+dbt==0.19.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -16,3 +16,7 @@ requests==2.22.0
 
 # quality (jsonschema, pytest - 2.0.0) vs. travis (tox, virtualenv - 1.7.0)
 importlib-metadata==1.7.0
+
+pyopenssl==19.1.0
+ 
+diff-cover<4.2.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,6 +17,8 @@ requests==2.22.0
 # quality (jsonschema, pytest - 2.0.0) vs. travis (tox, virtualenv - 1.7.0)
 importlib-metadata==1.7.0
 
+#Starting with pyOpenSSL 20.0.0, they upgraded cryptography version that is incompatible with snowflake-connector-python.
 pyopenssl==19.1.0
- 
+
+# 'pmap' package was not available
 diff-cover<4.2.0


### PR DESCRIPTION
After making changes in the constraints file I was able to run dbt_schema_builder tool on my local venv python 3.6.12
Followed this check list https://openedx.atlassian.net/wiki/spaces/DE/pages/1121059960/dbt+Upgrade+Checklist

**Description:** Describe in a couple of sentences what this PR adds

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc.

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
