### PR TITLE
support regex in unmanaged_tables.yml

### DIFF
--- a/dbt_schema_builder/relation.py
+++ b/dbt_schema_builder/relation.py
@@ -3,6 +3,7 @@ Class and helpers for dealing with DBT relations
 """
 
 import os
+import re
 
 import jinja2
 from dbt.logger import GLOBAL_LOGGER as logger
@@ -117,11 +118,16 @@ class Relation:
         """
         Is it "unmanaged" (i.e. it has been added to the list of unmanaged tables in
         unmanaged_tables.yml, indicating that we do not want schema builder to manage this table's
-        view-generating models), and
+        view-generating models)
         """
-        return (
-            "{}.{}".format(self.app, self.relation) in self.unmanaged_tables
-        )
+        for unmanaged_table in self.unmanaged_tables:
+            # make sure to include the EOL character in the regex, to prevent
+            # matching a substring in a larger string.
+            unmanaged_table_regex = re.compile(r'{}$'.format(unmanaged_table))
+            relation_name = "{}.{}".format(self.app, self.relation)
+            if re.search(unmanaged_table_regex, relation_name):
+                return True
+        return False
 
     @property
     def manual_safe_model_exists(self):

--- a/docs/redacting_pii.rst
+++ b/docs/redacting_pii.rst
@@ -43,7 +43,13 @@ These tables will not have any views built for them. If you wish to have them
 present in the <SCHEMA_PII> or <SCHEMA> schemas you will need to manually add
 models for them to the <SCHEMA>_MANUAL directory by hand.
 
-This YML file is managed by hand. An example file::
+This YML file is managed by hand. It supports two formats for identifying
+tables for manual managed tables::
+
+    - SCHEMA_NAME.TABLE_NAME          # explicitly define the snowflake identifier
+    - SCHEMA_NAME.WILDCARD_TABLE_.*   # explicitly define the schema and use a regex for the table name
+
+Here is an example file::
 
     # This file contains list tables that should have their models managed by
     # the schema builder tool in that form of SCHEMA.TABLE.
@@ -53,5 +59,5 @@ This YML file is managed by hand. An example file::
     # - LMS.AUTH_USER
 
     - FOO_SCHEMA.BAR_TABLE
-    - BAZ_SCHAME.BING_TABLE
+    - BAZ_SCHAME.BING_TABLE_[0-9]
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -125,3 +125,46 @@ def test_bad_source_config_format():
 
     err_msg = "Invalid source schema path in schema_config.yml"
     assert err_msg in str(excinfo.value)
+
+
+def test_valid_unmanaged_tables_file():
+    unmanaged_tables = []
+    assert SchemaBuilder.validate_unmanaged_tables(unmanaged_tables)
+    unmanaged_tables = [
+        'SCHEMA_1.TABLE_1',
+        'SCHEMA_1.TABLE_.*',
+        'SCHEMA_2.TABLE_[0-9]',
+    ]
+    assert SchemaBuilder.validate_unmanaged_tables(unmanaged_tables)
+
+
+def test_invalid_unmanaged_tables_file():
+    unmanaged_tables = [
+        'SCHEMA_1.TABLE_1',
+        'BAD_SCHEMA',
+        'SCHEMA_2.TABLE_1',
+    ]
+    with pytest.raises(InvalidConfigurationException) as excinfo:
+        SchemaBuilder.validate_unmanaged_tables(unmanaged_tables)
+
+    err_msg = (
+        'Entry "BAD_SCHEMA" in unmanaged_files.yml is not formatted '
+        'correctly.'
+    )
+    assert err_msg in str(excinfo.value)
+
+
+def test_bad_regex_unmanaged_tables_file():
+    unmanaged_tables = [
+        'SCHEMA_1.TABLE_1',
+        'SCHEMA_1.BAD_REGEX[',
+        'SCHEMA_2.TABLE_1',
+    ]
+    with pytest.raises(InvalidConfigurationException) as excinfo:
+        SchemaBuilder.validate_unmanaged_tables(unmanaged_tables)
+
+    err_msg = (
+        'Entry "SCHEMA_1.BAD_REGEX[" in unmanaged_files.yml contains '
+        'an invalid regular expression'
+    )
+    assert err_msg in str(excinfo.value)


### PR DESCRIPTION
We are planning on accepting a data share that includes 3 varieties per view: shared, PII, and non-PII. `shared` represents the combination of the latter two view types, which are deprecated and will be removed within the year. There are a lot of them, and this would mean a large unmanaged_tables file, that would need to be maintained over time. Instead, I have added a feature to support regular expressions in table names in this file.