### PR TITLE
fix: pinned MarkupSafe==2.0.1

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,3 +2,7 @@
 -c constraints.txt
 
 dbt==0.21.1
+
+# New release of MarkupSafe 2.1.0 is throwing an error "ImportError: cannot import name 'soft_unicode' from 'markupsafe'"
+# https://github.com/pallets/markupsafe/issues/282
+MarkupSafe==2.0.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,19 +12,19 @@ asn1crypto==1.4.0
     #   snowflake-connector-python
 attrs==21.4.0
     # via jsonschema
-azure-common==1.1.27
+azure-common==1.1.28
     # via snowflake-connector-python
-azure-core==1.21.1
+azure-core==1.22.1
     # via azure-storage-blob
 azure-storage-blob==12.9.0
     # via snowflake-connector-python
 babel==2.9.1
     # via agate
-boto3==1.20.32
+boto3==1.21.2
     # via
     #   dbt-redshift
     #   snowflake-connector-python
-botocore==1.23.32
+botocore==1.24.2
     # via
     #   boto3
     #   s3transfer
@@ -42,7 +42,7 @@ cffi==1.15.0
     #   snowflake-connector-python
 chardet==4.0.0
     # via snowflake-connector-python
-charset-normalizer==2.0.10
+charset-normalizer==2.0.12
     # via requests
 colorama==0.4.4
     # via dbt-core
@@ -51,6 +51,7 @@ cryptography==3.4.8
     #   azure-storage-blob
     #   dbt-snowflake
     #   pyopenssl
+    #   secretstorage
     #   snowflake-connector-python
 dbt==0.21.1
     # via -r requirements/base.in
@@ -82,7 +83,7 @@ google-auth==1.35.0
     # via
     #   google-api-core
     #   google-cloud-core
-google-cloud-bigquery==2.31.0
+google-cloud-bigquery==2.33.0
     # via dbt-bigquery
 google-cloud-core==1.7.2
     # via
@@ -90,13 +91,13 @@ google-cloud-core==1.7.2
     #   google-cloud-bigquery
 google-crc32c==1.3.0
     # via google-resumable-media
-google-resumable-media==2.1.0
+google-resumable-media==2.2.1
     # via google-cloud-bigquery
 googleapis-common-protos==1.54.0
     # via
     #   dbt-bigquery
     #   google-api-core
-grpcio==1.43.0
+grpcio==1.44.0
     # via
     #   google-api-core
     #   google-cloud-bigquery
@@ -107,13 +108,17 @@ idna==3.3
     #   dbt-core
     #   requests
     #   snowflake-connector-python
-importlib-metadata==4.10.0
+importlib-metadata==4.11.1
     # via jsonschema
 isodate==0.6.1
     # via
     #   agate
     #   dbt-core
     #   msrest
+jeepney==0.7.1
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==2.11.3
     # via dbt-core
 jmespath==0.10.0
@@ -131,7 +136,9 @@ leather==0.3.4
 logbook==1.5.3
     # via dbt-core
 markupsafe==2.0.1
-    # via jinja2
+    # via
+    #   -r requirements/base.in
+    #   jinja2
 mashumaro==2.5
     # via dbt-core
 minimal-snowplow-tracker==0.0.2
@@ -142,7 +149,7 @@ msrest==0.6.21
     # via azure-storage-blob
 networkx==2.6.3
     # via dbt-core
-oauthlib==3.1.1
+oauthlib==3.2.0
     # via requests-oauthlib
 oscrypto==1.2.1
     # via snowflake-connector-python
@@ -154,9 +161,9 @@ packaging==20.9
     #   google-cloud-bigquery
 parsedatetime==2.6
     # via agate
-proto-plus==1.19.8
+proto-plus==1.20.3
     # via google-cloud-bigquery
-protobuf==3.19.2
+protobuf==3.19.4
     # via
     #   dbt-bigquery
     #   google-api-core
@@ -173,22 +180,22 @@ pyasn1-modules==0.2.8
     # via google-auth
 pycparser==2.21
     # via cffi
-pycryptodomex==3.12.0
+pycryptodomex==3.14.1
     # via snowflake-connector-python
 pyjwt==2.3.0
     # via snowflake-connector-python
 pyopenssl==20.0.1
     # via snowflake-connector-python
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via jsonschema
 python-dateutil==2.8.2
     # via
     #   botocore
     #   google-cloud-bigquery
     #   hologram
-python-slugify==5.0.2
+python-slugify==6.0.1
     # via agate
 pytimeparse==1.1.8
     # via agate
@@ -212,12 +219,14 @@ requests==2.27.1
     #   msrest
     #   requests-oauthlib
     #   snowflake-connector-python
-requests-oauthlib==1.3.0
+requests-oauthlib==1.3.1
     # via msrest
 rsa==4.8
     # via google-auth
-s3transfer==0.5.0
+s3transfer==0.5.1
     # via boto3
+secretstorage==3.3.1
+    # via keyring
 six==1.16.0
     # via
     #   agate
@@ -247,7 +256,7 @@ urllib3==1.26.8
     # via
     #   botocore
     #   requests
-werkzeug==2.0.2
+werkzeug==2.0.3
     # via dbt-core
 zipp==3.7.0
     # via importlib-metadata

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,15 +6,15 @@
 #
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.10
+charset-normalizer==2.0.12
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.2
+coverage==6.3.1
     # via codecov
 distlib==0.3.4
     # via virtualenv
-filelock==3.4.2
+filelock==3.6.0
     # via
     #   tox
     #   virtualenv
@@ -24,13 +24,13 @@ packaging==20.9
     # via
     #   -c requirements/constraints.txt
     #   tox
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via packaging
 requests==2.27.1
     # via codecov
@@ -44,5 +44,5 @@ tox==3.24.5
     # via -r requirements/ci.in
 urllib3==1.26.8
     # via requests
-virtualenv==20.13.0
+virtualenv==20.13.1
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -23,11 +23,11 @@ attrs==21.4.0
     #   -r requirements/quality.txt
     #   jsonschema
     #   pytest
-azure-common==1.1.27
+azure-common==1.1.28
     # via
     #   -r requirements/quality.txt
     #   snowflake-connector-python
-azure-core==1.21.1
+azure-core==1.22.1
     # via
     #   -r requirements/quality.txt
     #   azure-storage-blob
@@ -39,12 +39,12 @@ babel==2.9.1
     # via
     #   -r requirements/quality.txt
     #   agate
-boto3==1.20.32
+boto3==1.21.2
     # via
     #   -r requirements/quality.txt
     #   dbt-redshift
     #   snowflake-connector-python
-botocore==1.23.32
+botocore==1.24.2
     # via
     #   -r requirements/quality.txt
     #   boto3
@@ -71,7 +71,7 @@ chardet==4.0.0
     #   -r requirements/quality.txt
     #   diff-cover
     #   snowflake-connector-python
-charset-normalizer==2.0.10
+charset-normalizer==2.0.12
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -88,7 +88,7 @@ click-log==0.3.2
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-code-annotations==1.2.0
+code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -98,7 +98,7 @@ colorama==0.4.4
     # via
     #   -r requirements/quality.txt
     #   dbt-core
-coverage[toml]==6.2
+coverage[toml]==6.3.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -110,6 +110,7 @@ cryptography==3.4.8
     #   azure-storage-blob
     #   dbt-snowflake
     #   pyopenssl
+    #   secretstorage
     #   snowflake-connector-python
 dbt==0.21.1
     # via -r requirements/quality.txt
@@ -150,7 +151,7 @@ distlib==0.3.4
     #   virtualenv
 edx-lint==5.2.1
     # via -r requirements/quality.txt
-filelock==3.4.2
+filelock==3.6.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -166,7 +167,7 @@ google-auth==1.35.0
     #   -r requirements/quality.txt
     #   google-api-core
     #   google-cloud-core
-google-cloud-bigquery==2.31.0
+google-cloud-bigquery==2.33.0
     # via
     #   -r requirements/quality.txt
     #   dbt-bigquery
@@ -179,7 +180,7 @@ google-crc32c==1.3.0
     # via
     #   -r requirements/quality.txt
     #   google-resumable-media
-google-resumable-media==2.1.0
+google-resumable-media==2.2.1
     # via
     #   -r requirements/quality.txt
     #   google-cloud-bigquery
@@ -188,7 +189,7 @@ googleapis-common-protos==1.54.0
     #   -r requirements/quality.txt
     #   dbt-bigquery
     #   google-api-core
-grpcio==1.43.0
+grpcio==1.44.0
     # via
     #   -r requirements/quality.txt
     #   google-api-core
@@ -204,7 +205,7 @@ idna==3.3
     #   dbt-core
     #   requests
     #   snowflake-connector-python
-importlib-metadata==4.10.0
+importlib-metadata==4.11.1
     # via
     #   -r requirements/quality.txt
     #   jsonschema
@@ -222,6 +223,11 @@ isort==5.10.1
     # via
     #   -r requirements/quality.txt
     #   pylint
+jeepney==0.7.1
+    # via
+    #   -r requirements/quality.txt
+    #   keyring
+    #   secretstorage
 jinja2==2.11.3
     # via
     #   -r requirements/quality.txt
@@ -285,7 +291,7 @@ networkx==2.6.3
     # via
     #   -r requirements/quality.txt
     #   dbt-core
-oauthlib==3.1.1
+oauthlib==3.2.0
     # via
     #   -r requirements/quality.txt
     #   requests-oauthlib
@@ -307,7 +313,7 @@ parsedatetime==2.6
     # via
     #   -r requirements/quality.txt
     #   agate
-pbr==5.8.0
+pbr==5.8.1
     # via
     #   -r requirements/quality.txt
     #   stevedore
@@ -315,9 +321,9 @@ pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements/pip-tools.txt
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -330,11 +336,11 @@ pluggy==1.0.0
     #   diff-cover
     #   pytest
     #   tox
-proto-plus==1.19.8
+proto-plus==1.20.3
     # via
     #   -r requirements/quality.txt
     #   google-cloud-bigquery
-protobuf==3.19.2
+protobuf==3.19.4
     # via
     #   -r requirements/quality.txt
     #   dbt-bigquery
@@ -367,7 +373,7 @@ pycparser==2.21
     # via
     #   -r requirements/quality.txt
     #   cffi
-pycryptodomex==3.12.0
+pycryptodomex==3.14.1
     # via
     #   -r requirements/quality.txt
     #   snowflake-connector-python
@@ -390,7 +396,7 @@ pylint-celery==0.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-pylint-django==2.5.0
+pylint-django==2.5.2
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -403,16 +409,16 @@ pyopenssl==20.0.1
     # via
     #   -r requirements/quality.txt
     #   snowflake-connector-python
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   packaging
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via
     #   -r requirements/quality.txt
     #   jsonschema
-pytest==6.2.5
+pytest==7.0.1
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -424,7 +430,7 @@ python-dateutil==2.8.2
     #   botocore
     #   google-cloud-bigquery
     #   hologram
-python-slugify==5.0.2
+python-slugify==6.0.1
     # via
     #   -r requirements/quality.txt
     #   agate
@@ -459,7 +465,7 @@ requests==2.27.1
     #   msrest
     #   requests-oauthlib
     #   snowflake-connector-python
-requests-oauthlib==1.3.0
+requests-oauthlib==1.3.1
     # via
     #   -r requirements/quality.txt
     #   msrest
@@ -467,10 +473,14 @@ rsa==4.8
     # via
     #   -r requirements/quality.txt
     #   google-auth
-s3transfer==0.5.0
+s3transfer==0.5.1
     # via
     #   -r requirements/quality.txt
     #   boto3
+secretstorage==3.3.1
+    # via
+    #   -r requirements/quality.txt
+    #   keyring
 six==1.16.0
     # via
     #   -r requirements/ci.txt
@@ -516,14 +526,14 @@ toml==0.10.2
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pylint
-    #   pytest
     #   tox
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   coverage
     #   pep517
+    #   pytest
 tox==3.24.5
     # via
     #   -r requirements/ci.txt
@@ -543,11 +553,11 @@ urllib3==1.26.8
     #   -r requirements/quality.txt
     #   botocore
     #   requests
-virtualenv==20.13.0
+virtualenv==20.13.1
     # via
     #   -r requirements/ci.txt
     #   tox
-werkzeug==2.0.2
+werkzeug==2.0.3
     # via
     #   -r requirements/quality.txt
     #   dbt-core

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -20,11 +20,11 @@ attrs==21.4.0
     #   -r requirements/test.txt
     #   jsonschema
     #   pytest
-azure-common==1.1.27
+azure-common==1.1.28
     # via
     #   -r requirements/test.txt
     #   snowflake-connector-python
-azure-core==1.21.1
+azure-core==1.22.1
     # via
     #   -r requirements/test.txt
     #   azure-storage-blob
@@ -39,12 +39,12 @@ babel==2.9.1
     #   sphinx
 bleach==4.1.0
     # via readme-renderer
-boto3==1.20.32
+boto3==1.21.2
     # via
     #   -r requirements/test.txt
     #   dbt-redshift
     #   snowflake-connector-python
-botocore==1.23.32
+botocore==1.24.2
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -69,7 +69,7 @@ chardet==4.0.0
     # via
     #   -r requirements/test.txt
     #   snowflake-connector-python
-charset-normalizer==2.0.10
+charset-normalizer==2.0.12
     # via
     #   -r requirements/test.txt
     #   requests
@@ -77,7 +77,7 @@ colorama==0.4.4
     # via
     #   -r requirements/test.txt
     #   dbt-core
-coverage[toml]==6.2
+coverage[toml]==6.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -87,6 +87,7 @@ cryptography==3.4.8
     #   azure-storage-blob
     #   dbt-snowflake
     #   pyopenssl
+    #   secretstorage
     #   snowflake-connector-python
 dbt==0.21.1
     # via -r requirements/test.txt
@@ -140,7 +141,7 @@ google-auth==1.35.0
     #   -r requirements/test.txt
     #   google-api-core
     #   google-cloud-core
-google-cloud-bigquery==2.31.0
+google-cloud-bigquery==2.33.0
     # via
     #   -r requirements/test.txt
     #   dbt-bigquery
@@ -153,7 +154,7 @@ google-crc32c==1.3.0
     # via
     #   -r requirements/test.txt
     #   google-resumable-media
-google-resumable-media==2.1.0
+google-resumable-media==2.2.1
     # via
     #   -r requirements/test.txt
     #   google-cloud-bigquery
@@ -162,7 +163,7 @@ googleapis-common-protos==1.54.0
     #   -r requirements/test.txt
     #   dbt-bigquery
     #   google-api-core
-grpcio==1.43.0
+grpcio==1.44.0
     # via
     #   -r requirements/test.txt
     #   google-api-core
@@ -179,10 +180,11 @@ idna==3.3
     #   snowflake-connector-python
 imagesize==1.3.0
     # via sphinx
-importlib-metadata==4.10.0
+importlib-metadata==4.11.1
     # via
     #   -r requirements/test.txt
     #   jsonschema
+    #   sphinx
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
@@ -193,6 +195,11 @@ isodate==0.6.1
     #   agate
     #   dbt-core
     #   msrest
+jeepney==0.7.1
+    # via
+    #   -r requirements/test.txt
+    #   keyring
+    #   secretstorage
 jinja2==2.11.3
     # via
     #   -r requirements/test.txt
@@ -247,7 +254,7 @@ networkx==2.6.3
     # via
     #   -r requirements/test.txt
     #   dbt-core
-oauthlib==3.1.1
+oauthlib==3.2.0
     # via
     #   -r requirements/test.txt
     #   requests-oauthlib
@@ -269,17 +276,17 @@ parsedatetime==2.6
     # via
     #   -r requirements/test.txt
     #   agate
-pbr==5.8.0
+pbr==5.8.1
     # via stevedore
 pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-proto-plus==1.19.8
+proto-plus==1.20.3
     # via
     #   -r requirements/test.txt
     #   google-cloud-bigquery
-protobuf==3.19.2
+protobuf==3.19.4
     # via
     #   -r requirements/test.txt
     #   dbt-bigquery
@@ -308,7 +315,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.12.0
+pycryptodomex==3.14.1
     # via
     #   -r requirements/test.txt
     #   snowflake-connector-python
@@ -325,15 +332,15 @@ pyopenssl==20.0.1
     # via
     #   -r requirements/test.txt
     #   snowflake-connector-python
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via
     #   -r requirements/test.txt
     #   packaging
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via
     #   -r requirements/test.txt
     #   jsonschema
-pytest==6.2.5
+pytest==7.0.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -345,7 +352,7 @@ python-dateutil==2.8.2
     #   botocore
     #   google-cloud-bigquery
     #   hologram
-python-slugify==5.0.2
+python-slugify==6.0.1
     # via
     #   -r requirements/test.txt
     #   agate
@@ -379,7 +386,7 @@ requests==2.27.1
     #   requests-oauthlib
     #   snowflake-connector-python
     #   sphinx
-requests-oauthlib==1.3.0
+requests-oauthlib==1.3.1
     # via
     #   -r requirements/test.txt
     #   msrest
@@ -389,10 +396,14 @@ rsa==4.8
     # via
     #   -r requirements/test.txt
     #   google-auth
-s3transfer==0.5.0
+s3transfer==0.5.1
     # via
     #   -r requirements/test.txt
     #   boto3
+secretstorage==3.3.1
+    # via
+    #   -r requirements/test.txt
+    #   keyring
 six==1.16.0
     # via
     #   -r requirements/test.txt
@@ -417,7 +428,7 @@ snowflake-connector-python[secure-local-storage]==2.5.1
     # via
     #   -r requirements/test.txt
     #   dbt-snowflake
-sphinx==4.3.2
+sphinx==4.4.0
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -443,14 +454,11 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-toml==0.10.2
-    # via
-    #   -r requirements/test.txt
-    #   pytest
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   -r requirements/test.txt
     #   coverage
+    #   pytest
 typing-extensions==3.10.0.2
     # via
     #   -r requirements/test.txt
@@ -463,7 +471,7 @@ urllib3==1.26.8
     #   requests
 webencodings==0.5.1
     # via bleach
-werkzeug==2.0.2
+werkzeug==2.0.3
     # via
     #   -r requirements/test.txt
     #   dbt-core

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,9 +8,9 @@ click==8.0.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via -r requirements/pip-tools.in
-tomli==2.0.0
+tomli==2.0.1
     # via pep517
 wheel==0.37.1
     # via pip-tools

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.3.1
+pip==22.0.3
     # via -r requirements/pip.in
-setuptools==60.5.0
+setuptools==60.9.3
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -22,11 +22,11 @@ attrs==21.4.0
     #   -r requirements/test.txt
     #   jsonschema
     #   pytest
-azure-common==1.1.27
+azure-common==1.1.28
     # via
     #   -r requirements/test.txt
     #   snowflake-connector-python
-azure-core==1.21.1
+azure-core==1.22.1
     # via
     #   -r requirements/test.txt
     #   azure-storage-blob
@@ -38,12 +38,12 @@ babel==2.9.1
     # via
     #   -r requirements/test.txt
     #   agate
-boto3==1.20.32
+boto3==1.21.2
     # via
     #   -r requirements/test.txt
     #   dbt-redshift
     #   snowflake-connector-python
-botocore==1.23.32
+botocore==1.24.2
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -68,7 +68,7 @@ chardet==4.0.0
     # via
     #   -r requirements/test.txt
     #   snowflake-connector-python
-charset-normalizer==2.0.10
+charset-normalizer==2.0.12
     # via
     #   -r requirements/test.txt
     #   requests
@@ -79,13 +79,13 @@ click==8.0.3
     #   edx-lint
 click-log==0.3.2
     # via edx-lint
-code-annotations==1.2.0
+code-annotations==1.3.0
     # via edx-lint
 colorama==0.4.4
     # via
     #   -r requirements/test.txt
     #   dbt-core
-coverage[toml]==6.2
+coverage[toml]==6.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -95,6 +95,7 @@ cryptography==3.4.8
     #   azure-storage-blob
     #   dbt-snowflake
     #   pyopenssl
+    #   secretstorage
     #   snowflake-connector-python
 dbt==0.21.1
     # via -r requirements/test.txt
@@ -140,7 +141,7 @@ google-auth==1.35.0
     #   -r requirements/test.txt
     #   google-api-core
     #   google-cloud-core
-google-cloud-bigquery==2.31.0
+google-cloud-bigquery==2.33.0
     # via
     #   -r requirements/test.txt
     #   dbt-bigquery
@@ -153,7 +154,7 @@ google-crc32c==1.3.0
     # via
     #   -r requirements/test.txt
     #   google-resumable-media
-google-resumable-media==2.1.0
+google-resumable-media==2.2.1
     # via
     #   -r requirements/test.txt
     #   google-cloud-bigquery
@@ -162,7 +163,7 @@ googleapis-common-protos==1.54.0
     #   -r requirements/test.txt
     #   dbt-bigquery
     #   google-api-core
-grpcio==1.43.0
+grpcio==1.44.0
     # via
     #   -r requirements/test.txt
     #   google-api-core
@@ -177,7 +178,7 @@ idna==3.3
     #   dbt-core
     #   requests
     #   snowflake-connector-python
-importlib-metadata==4.10.0
+importlib-metadata==4.11.1
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -195,6 +196,11 @@ isort==5.10.1
     # via
     #   -r requirements/quality.in
     #   pylint
+jeepney==0.7.1
+    # via
+    #   -r requirements/test.txt
+    #   keyring
+    #   secretstorage
 jinja2==2.11.3
     # via
     #   -r requirements/test.txt
@@ -253,7 +259,7 @@ networkx==2.6.3
     # via
     #   -r requirements/test.txt
     #   dbt-core
-oauthlib==3.1.1
+oauthlib==3.2.0
     # via
     #   -r requirements/test.txt
     #   requests-oauthlib
@@ -273,19 +279,19 @@ parsedatetime==2.6
     # via
     #   -r requirements/test.txt
     #   agate
-pbr==5.8.0
+pbr==5.8.1
     # via stevedore
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via pylint
 pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-proto-plus==1.19.8
+proto-plus==1.20.3
     # via
     #   -r requirements/test.txt
     #   google-cloud-bigquery
-protobuf==3.19.2
+protobuf==3.19.4
     # via
     #   -r requirements/test.txt
     #   dbt-bigquery
@@ -316,7 +322,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.12.0
+pycryptodomex==3.14.1
     # via
     #   -r requirements/test.txt
     #   snowflake-connector-python
@@ -334,7 +340,7 @@ pylint==2.12.2
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.5.0
+pylint-django==2.5.2
     # via edx-lint
 pylint-plugin-utils==0.7
     # via
@@ -344,15 +350,15 @@ pyopenssl==20.0.1
     # via
     #   -r requirements/test.txt
     #   snowflake-connector-python
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via
     #   -r requirements/test.txt
     #   packaging
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via
     #   -r requirements/test.txt
     #   jsonschema
-pytest==6.2.5
+pytest==7.0.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -364,7 +370,7 @@ python-dateutil==2.8.2
     #   botocore
     #   google-cloud-bigquery
     #   hologram
-python-slugify==5.0.2
+python-slugify==6.0.1
     # via
     #   -r requirements/test.txt
     #   agate
@@ -397,7 +403,7 @@ requests==2.27.1
     #   msrest
     #   requests-oauthlib
     #   snowflake-connector-python
-requests-oauthlib==1.3.0
+requests-oauthlib==1.3.1
     # via
     #   -r requirements/test.txt
     #   msrest
@@ -405,10 +411,14 @@ rsa==4.8
     # via
     #   -r requirements/test.txt
     #   google-auth
-s3transfer==0.5.0
+s3transfer==0.5.1
     # via
     #   -r requirements/test.txt
     #   boto3
+secretstorage==3.3.1
+    # via
+    #   -r requirements/test.txt
+    #   keyring
 six==1.16.0
     # via
     #   -r requirements/test.txt
@@ -443,14 +453,12 @@ text-unidecode==1.3
     #   -r requirements/test.txt
     #   python-slugify
 toml==0.10.2
-    # via
-    #   -r requirements/test.txt
-    #   pylint
-    #   pytest
-tomli==2.0.0
+    # via pylint
+tomli==2.0.1
     # via
     #   -r requirements/test.txt
     #   coverage
+    #   pytest
 typing-extensions==3.10.0.2
     # via
     #   -r requirements/test.txt
@@ -463,7 +471,7 @@ urllib3==1.26.8
     #   -r requirements/test.txt
     #   botocore
     #   requests
-werkzeug==2.0.2
+werkzeug==2.0.3
     # via
     #   -r requirements/test.txt
     #   dbt-core

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,11 +18,11 @@ attrs==21.4.0
     #   -r requirements/base.txt
     #   jsonschema
     #   pytest
-azure-common==1.1.27
+azure-common==1.1.28
     # via
     #   -r requirements/base.txt
     #   snowflake-connector-python
-azure-core==1.21.1
+azure-core==1.22.1
     # via
     #   -r requirements/base.txt
     #   azure-storage-blob
@@ -34,12 +34,12 @@ babel==2.9.1
     # via
     #   -r requirements/base.txt
     #   agate
-boto3==1.20.32
+boto3==1.21.2
     # via
     #   -r requirements/base.txt
     #   dbt-redshift
     #   snowflake-connector-python
-botocore==1.23.32
+botocore==1.24.2
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -64,7 +64,7 @@ chardet==4.0.0
     # via
     #   -r requirements/base.txt
     #   snowflake-connector-python
-charset-normalizer==2.0.10
+charset-normalizer==2.0.12
     # via
     #   -r requirements/base.txt
     #   requests
@@ -72,7 +72,7 @@ colorama==0.4.4
     # via
     #   -r requirements/base.txt
     #   dbt-core
-coverage[toml]==6.2
+coverage[toml]==6.3.1
     # via pytest-cov
 cryptography==3.4.8
     # via
@@ -80,6 +80,7 @@ cryptography==3.4.8
     #   azure-storage-blob
     #   dbt-snowflake
     #   pyopenssl
+    #   secretstorage
     #   snowflake-connector-python
 dbt==0.21.1
     # via -r requirements/base.txt
@@ -123,7 +124,7 @@ google-auth==1.35.0
     #   -r requirements/base.txt
     #   google-api-core
     #   google-cloud-core
-google-cloud-bigquery==2.31.0
+google-cloud-bigquery==2.33.0
     # via
     #   -r requirements/base.txt
     #   dbt-bigquery
@@ -136,7 +137,7 @@ google-crc32c==1.3.0
     # via
     #   -r requirements/base.txt
     #   google-resumable-media
-google-resumable-media==2.1.0
+google-resumable-media==2.2.1
     # via
     #   -r requirements/base.txt
     #   google-cloud-bigquery
@@ -145,7 +146,7 @@ googleapis-common-protos==1.54.0
     #   -r requirements/base.txt
     #   dbt-bigquery
     #   google-api-core
-grpcio==1.43.0
+grpcio==1.44.0
     # via
     #   -r requirements/base.txt
     #   google-api-core
@@ -160,7 +161,7 @@ idna==3.3
     #   dbt-core
     #   requests
     #   snowflake-connector-python
-importlib-metadata==4.10.0
+importlib-metadata==4.11.1
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -172,6 +173,11 @@ isodate==0.6.1
     #   agate
     #   dbt-core
     #   msrest
+jeepney==0.7.1
+    # via
+    #   -r requirements/base.txt
+    #   keyring
+    #   secretstorage
 jinja2==2.11.3
     # via
     #   -r requirements/base.txt
@@ -225,7 +231,7 @@ networkx==2.6.3
     # via
     #   -r requirements/base.txt
     #   dbt-core
-oauthlib==3.1.1
+oauthlib==3.2.0
     # via
     #   -r requirements/base.txt
     #   requests-oauthlib
@@ -247,11 +253,11 @@ parsedatetime==2.6
     #   agate
 pluggy==1.0.0
     # via pytest
-proto-plus==1.19.8
+proto-plus==1.20.3
     # via
     #   -r requirements/base.txt
     #   google-cloud-bigquery
-protobuf==3.19.2
+protobuf==3.19.4
     # via
     #   -r requirements/base.txt
     #   dbt-bigquery
@@ -278,7 +284,7 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.12.0
+pycryptodomex==3.14.1
     # via
     #   -r requirements/base.txt
     #   snowflake-connector-python
@@ -290,15 +296,15 @@ pyopenssl==20.0.1
     # via
     #   -r requirements/base.txt
     #   snowflake-connector-python
-pyparsing==3.0.6
+pyparsing==3.0.7
     # via
     #   -r requirements/base.txt
     #   packaging
-pyrsistent==0.18.0
+pyrsistent==0.18.1
     # via
     #   -r requirements/base.txt
     #   jsonschema
-pytest==6.2.5
+pytest==7.0.1
     # via pytest-cov
 pytest-cov==3.0.0
     # via -r requirements/test.in
@@ -308,7 +314,7 @@ python-dateutil==2.8.2
     #   botocore
     #   google-cloud-bigquery
     #   hologram
-python-slugify==5.0.2
+python-slugify==6.0.1
     # via
     #   -r requirements/base.txt
     #   agate
@@ -339,7 +345,7 @@ requests==2.27.1
     #   msrest
     #   requests-oauthlib
     #   snowflake-connector-python
-requests-oauthlib==1.3.0
+requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   msrest
@@ -347,10 +353,14 @@ rsa==4.8
     # via
     #   -r requirements/base.txt
     #   google-auth
-s3transfer==0.5.0
+s3transfer==0.5.1
     # via
     #   -r requirements/base.txt
     #   boto3
+secretstorage==3.3.1
+    # via
+    #   -r requirements/base.txt
+    #   keyring
 six==1.16.0
     # via
     #   -r requirements/base.txt
@@ -379,10 +389,10 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-toml==0.10.2
-    # via pytest
-tomli==2.0.0
-    # via coverage
+tomli==2.0.1
+    # via
+    #   coverage
+    #   pytest
 typing-extensions==3.10.0.2
     # via
     #   -r requirements/base.txt
@@ -393,7 +403,7 @@ urllib3==1.26.8
     #   -r requirements/base.txt
     #   botocore
     #   requests
-werkzeug==2.0.2
+werkzeug==2.0.3
     # via
     #   -r requirements/base.txt
     #   dbt-core


### PR DESCRIPTION
schema builder job started failing today. It was because of MarkupSafe 2.1.0 version throwing error. So pinning the version MarkupSafe==2.0.1

**Description:** Describe in a couple of sentences what this PR adds

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc.

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
