### PR TITLE
fix: Updated dbt-core and dbt-snowflake version to resolve dependenci…

### DIFF
--- a/dbt_schema_builder/__init__.py
+++ b/dbt_schema_builder/__init__.py
@@ -2,4 +2,4 @@
 Automate management of PII redacted schemas for dbt projects.
 """
 
-__version__ = '0.4.4'
+__version__ = '0.4.5'

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,5 @@
 # Core requirements for using this application
 -c constraints.txt
 
-dbt-core==1.0.3
-dbt-snowflake==1.0.0
+dbt-core==1.2.0
+dbt-snowflake==1.2.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,3 +13,18 @@ packaging==20.9
 # Pinning snowflake-connector-python due to following issue
 # https://github.com/snowflakedb/snowflake-connector-python/issues/1206
 snowflake-connector-python==2.7.9
+
+# Pinning below mentioned dependencies because when we do make upgrade there is conflict between dependencies
+# snowflake-connector-python 2.7.9 install werkzeug 2.2.2 in which MarkupSafe is pinned to MarkupSafe>=2.1.1
+# https://github.com/pallets/werkzeug/blob/2.2.2/setup.py
+# This cause error: Could not find a version that matches MarkupSafe==2.0.1,==2.1.1 (from -c requirements/constraints.txt (line 17))
+# Because in dbt-score 1.0.3 MarkupSafe is pinned to 2.0.1 and in dbt-score 1.2.0 MarkupSafe is pinned to MarkupSafe>=0.23,<2.1 
+# https://github.com/dbt-labs/dbt-core/blob/v1.2.0/core/setup.py#L52
+# https://github.com/dbt-labs/dbt-core/blob/v1.0.3/core/setup.py#L55
+# Due to this reason we are pinnig to werkzeug==2.1.2, becuase in this version MarkupSafe is not pinned
+# https://github.com/pallets/werkzeug/blob/2.1.2/setup.py
+# Also with this change dbt-core and dbt-snowflake version was dumped to 1.2.0 in base.in file
+# becuase dbt-snowflake==1.0.0 has hard limit cryptography<4,>=3.2 and snowflake-connector-python==2.7.9 has hard limit cryptography<37.0.0,>=3.1.0. 
+# This was causing conflict so needed to upgrade dbt-snowflake and dbt-core to 1.2.0
+werkzeug==2.1.2
+charset-normalizer==2.0.12


### PR DESCRIPTION
…es conflict

**Description:** 
In our previous merge : https://github.com/edx/dbt-schema-builder/commit/a3c67ecc13afd4f55ad950527c767a28003e8916 we downgraded snowflake-connector-python from 2.7.10 to 2.7.9 due to following issue https://github.com/snowflakedb/snowflake-connector-python/issues/1206
Due to this change we were facing error while doing make upgrade 
**ERROR:** Could not find a version that matches MarkupSafe==2.0.1,==2.1.1. There are incompatible versions in the resolved dependencies

We upgraded dbt-core and dbt-snowlfake and also pinned some dependencies to resolve this issue.

**JIRA:** https://2u-internal.atlassian.net/browse/DENG-1297

**Dependencies:** dependencies on other outstanding PRs, issues, etc.

**Merge deadline:** List merge deadline (if any)

**Installation instructions:** List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
