### PR TITLE
build: remove unnecessary codecov dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Run Tests
       run: tox
     - name: Run Coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
   run_dbt_schema_builder_code_quality:

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -1,5 +1,4 @@
 # Requirements for running tests in CI
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,8 +8,6 @@ certifi==2021.10.8
     # via requests
 charset-normalizer==2.0.12
     # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
 coverage==6.3.2
     # via codecov
 distlib==0.3.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -64,8 +64,6 @@ code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-codecov==2.1.12
-    # via -r requirements/ci.txt
 colorama==0.4.4
     # via
     #   -r requirements/quality.txt

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ commands =
 [testenv:docs]
 setenv =
     PYTHONPATH = {toxinidir}
-whitelist_externals =
+allowlist_externals =
     make
     rm
 deps =
@@ -41,7 +41,7 @@ commands =
     python setup.py check --restructuredtext --strict
 
 [testenv:quality]
-whitelist_externals =
+allowlist_externals =
     make
     rm
     touch


### PR DESCRIPTION
**Description:** On Wednesday this happened with Codecov: https://about.codecov.io/blog/message-regarding-the-pypi-package/

Since codecov's GHA-based uploader doesn't depend on this package, this PR removes it.